### PR TITLE
Physics Interactive Visualisation

### DIFF
--- a/app/src/main/java/pratheekv39/bridgelearn/io/LearnScreen.kt
+++ b/app/src/main/java/pratheekv39/bridgelearn/io/LearnScreen.kt
@@ -123,20 +123,27 @@ fun SubjectLearningContent(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             items(subject.learningContent) { content ->
-                LearningContentCard(content,navController)
+                LearningContentCard(content,navController,subject)
             }
         }
     }
 }
 
 @Composable
-fun LearningContentCard(content: LearningContent,navController: NavController) {
+fun LearningContentCard(content: LearningContent,navController: NavController,subject: LearnSubject) {
     Card(
         modifier = Modifier.fillMaxWidth().clickable {
-            if(content.id=="1"){
-                navController.navigate("Interactive")
-
-
+            when {
+                subject.id == "physics" && content.id == "1" -> {
+                    navController.navigate("Pendulum")
+                }
+                subject.id == "chemistry" && content.id == "1" -> {
+                    navController.navigate("Interactive")
+                }
+                subject.id == "physics" && content.id == "2" -> {
+                    navController.navigate("Spring")
+                }
+                // Add more conditions as needed
             }
         }
     ) {

--- a/app/src/main/java/pratheekv39/bridgelearn/io/LearnViewModel.kt
+++ b/app/src/main/java/pratheekv39/bridgelearn/io/LearnViewModel.kt
@@ -14,9 +14,10 @@ class LearnViewModel : ViewModel() {
             name = "Physics",
             description = "Learn about forces and energy",
             learningContent = listOf(
-                LearningContent("1", "Introduction to Forces", ContentType.VIDEO, 0.8f),
-                LearningContent("2", "Newton's Laws", ContentType.SIMULATION, 0.5f),
-                LearningContent("3", "Energy Conservation", ContentType.READING, 0.3f)
+                LearningContent("1", "Pendulum Simulator", ContentType.SIMULATION, 0.8f),
+                LearningContent("2", "Spring Simulator", ContentType.SIMULATION, 0.8f),
+                LearningContent("3", "Newton's Laws", ContentType.SIMULATION, 0.5f),
+                LearningContent("4", "Energy Conservation", ContentType.READING, 0.3f)
             )
         ),
         LearnSubject(

--- a/app/src/main/java/pratheekv39/bridgelearn/io/MainActivity.kt
+++ b/app/src/main/java/pratheekv39/bridgelearn/io/MainActivity.kt
@@ -29,7 +29,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    NavGraph()
+                   NavGraph()
                 }
             }
         }

--- a/app/src/main/java/pratheekv39/bridgelearn/io/NavGraph.kt
+++ b/app/src/main/java/pratheekv39/bridgelearn/io/NavGraph.kt
@@ -1,5 +1,6 @@
 package pratheekv39.bridgelearn.io
 
+import PendulumSimulation
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.padding
@@ -95,7 +96,7 @@ fun NavGraph(
             val currentRoute = navBackStackEntry?.destination?.route
 
             // Hide the bottom bar when on the "Interactive" screen
-            if (currentRoute != "Interactive") {
+            if (currentRoute !in listOf("Interactive", "Pendulum", "Spring")) {
                 NavigationBar {
                     screens.forEach { screen ->
                         NavigationBarItem(
@@ -146,6 +147,14 @@ fun NavGraph(
             composable("Interactive") {
                 AcidBaseInteractiveLab(navController)
             }
+            composable("Pendulum") {
+                PendulumSimulation(navController)
+            }
+            composable("Spring") {
+                SpringSimulation(navController)
+            }
+
+
 
             composable(Screen.Learn.route) { LearnScreen(navController) }
 

--- a/app/src/main/java/pratheekv39/bridgelearn/io/PendulumSimulator.kt
+++ b/app/src/main/java/pratheekv39/bridgelearn/io/PendulumSimulator.kt
@@ -1,0 +1,210 @@
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlin.math.*
+
+
+@Composable
+fun PendulumSimulation( navController: NavController) {
+    var length by remember { mutableStateOf(200f) }
+    var initialAngle by remember { mutableStateOf(45f) }
+    var isRunning by remember { mutableStateOf(false) }
+
+    val g = 9.8f
+    val lengthMeters = length / 100
+    val period = 2 * PI * sqrt(lengthMeters / g)
+
+    var time by remember { mutableStateOf(0f) }
+    val angle = remember { Animatable(initialAngle) }
+
+    LaunchedEffect(initialAngle) {
+        angle.snapTo(initialAngle)
+    }
+
+    LaunchedEffect(isRunning) {
+        if (isRunning) {
+            while (isRunning) {
+                val omega = sqrt(g / lengthMeters)
+                time += 0.016f
+                val newAngle = initialAngle * cos(omega * time)
+                angle.snapTo(newAngle)
+                kotlinx.coroutines.delay(16)
+            }
+        } else {
+            time = 0f
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0XFF37B6E9))
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp, bottom = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Pendulum Simulation", style = MaterialTheme.typography.titleLarge, color = Color.Black, fontWeight = FontWeight.Bold)
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp).background(Color(0xFFF8F9FA)),
+            elevation =CardDefaults.cardElevation(4.dp),
+            shape = RoundedCornerShape(12.dp),
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text("Length: ${length.toInt()/100}m ", color = Color.Black)
+                Slider(
+                    value = length,
+                    onValueChange = { length = it },
+                    valueRange = 100f..500f,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    colors = SliderDefaults.colors(
+                        thumbColor = Color.Cyan,
+                        activeTrackColor = Color.Blue
+                    )
+                )
+
+                Text("Initial Angle: ${initialAngle.toInt()}°", color = Color.Black)
+                Slider(
+                    value = initialAngle,
+                    onValueChange = { initialAngle = it },
+                    valueRange = -90f..90f,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    colors = SliderDefaults.colors(
+                        thumbColor = Color.Red,
+                        activeTrackColor = Color.Magenta
+                    )
+                )
+            }
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Button(
+                onClick = { isRunning = true },
+                colors = ButtonDefaults.buttonColors(contentColor = Color.Green)
+            ) {
+                Text("Start", color = Color.White)
+            }
+            Button(
+                onClick = { isRunning = false },
+                colors = ButtonDefaults.buttonColors(contentColor = Color.Red)
+            ) {
+                Text("Stop", color = Color.White)
+            }
+            Button(
+                onClick = {
+                    isRunning = false
+                    time = 0f
+                    GlobalScope.launch { angle.snapTo(initialAngle) }
+
+                },
+                colors = ButtonDefaults.buttonColors(contentColor = Color.Gray)
+            ) {
+                Text("Reset", color = Color.White)
+            }
+        }
+
+        Text("Period: ${"%.2f".format(period)} s", color = Color.Yellow, modifier = Modifier.padding(8.dp),
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 20.sp
+        )
+
+        // Pendulum visualization
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val pivotX = size.width / 2
+                val pivotY = size.height / 4
+                val bobX = pivotX + length * sin(Math.toRadians(angle.value.toDouble())).toFloat()
+                val bobY = pivotY + length * cos(Math.toRadians(angle.value.toDouble())).toFloat()
+
+
+                drawCircle(
+                    color = Color.Yellow,
+                    radius = 12f,
+                    center = Offset(pivotX, pivotY)
+                )
+
+                drawLine(
+                    brush = Brush.linearGradient(
+                        colors = listOf(Color.Cyan, Color.Blue)
+                    ),
+                    start = Offset(pivotX, pivotY),
+                    end = Offset(bobX, bobY),
+                    strokeWidth = 5f
+                )
+
+                drawCircle(
+                    brush = Brush.radialGradient(
+                        colors = listOf(Color.Yellow, Color.DarkGray),
+                        center = Offset(bobX, bobY),
+                        radius = 30f
+                    ),
+                    radius = 30f,
+                    center = Offset(bobX, bobY)
+                )
+
+                val velocity = -sqrt(g / lengthMeters) * length * sin(Math.toRadians(angle.value.toDouble())).toFloat()
+                drawLine(
+                    color = Color.White,
+                    start = Offset(bobX, bobY),
+                    end = Offset(bobX + velocity / 10, bobY),
+                    strokeWidth = 5f
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/pratheekv39/bridgelearn/io/SpringSimulation.kt
+++ b/app/src/main/java/pratheekv39/bridgelearn/io/SpringSimulation.kt
@@ -1,0 +1,229 @@
+package pratheekv39.bridgelearn.io
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+@Composable
+fun SpringSimulation(navController: NavController) {
+    var springConstant by remember { mutableStateOf(50f) }
+    var mass by remember { mutableStateOf(1f) }
+    var displacement by remember { mutableStateOf(100f) }
+    var isRunning by remember { mutableStateOf(false) }
+
+    val equilibriumY = 400f
+    val g = 9.8f
+    val displacementMeters = displacement / 100
+    val angularFrequency = sqrt(springConstant / mass)
+    val period = (2 * PI / angularFrequency).toFloat()
+
+    var time by remember { mutableStateOf(0f) }
+    val currentDisplacement = remember { Animatable(displacement) }
+
+    LaunchedEffect(isRunning) {
+        if (isRunning) {
+            while (isRunning) {
+                time += 0.016f
+                val newDisplacement = displacement * cos(angularFrequency * time)
+                currentDisplacement.snapTo(newDisplacement)
+                kotlinx.coroutines.delay(16) // 60 FPS
+            }
+        } else {
+            time = 0f
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0XFF37B6E9))
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp, bottom = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Spring Simulation", style = MaterialTheme.typography.titleLarge, color = Color.Black, fontWeight = FontWeight.Bold)
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp).background(Color(0xFFF8F9FA)),
+            elevation = CardDefaults.cardElevation(8.dp),
+            shape = RoundedCornerShape(12.dp),
+
+            ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text("Spring Constant: ${springConstant.toInt()} N/m", color = Color.Black)
+                Slider(
+                    value = springConstant,
+                    onValueChange = { springConstant = it },
+                    valueRange = 10f..100f,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    colors = SliderDefaults.colors(
+                        thumbColor = Color.Cyan,
+                        activeTrackColor = Color.Blue
+                    )
+                )
+
+                Text("Mass: ${"%.2f".format(mass)} kg", color = Color.Black)
+                Slider(
+                    value = mass,
+                    onValueChange = { mass = it },
+                    valueRange = 0.5f..5f,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    colors = SliderDefaults.colors(
+                        thumbColor = Color.Red,
+                        activeTrackColor = Color.Magenta
+                    )
+                )
+
+                Text("Initial Displacement: ${displacement.toInt()/100} m", color = Color.Black)
+                Slider(
+                    value = displacement,
+                    onValueChange = { displacement = it },
+                    valueRange = 50f..500f,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    colors = SliderDefaults.colors(
+                        thumbColor = Color.Yellow,
+                        activeTrackColor = Color.Green
+                    )
+                )
+            }
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Button(
+                onClick = { isRunning = true },
+                colors = ButtonDefaults.buttonColors(contentColor = Color.Green)
+            ) {
+                Text("Start", color = Color.White)
+            }
+            Button(
+                onClick = { isRunning = false },
+                colors = ButtonDefaults.buttonColors(contentColor = Color.Red)
+            ) {
+                Text("Stop", color = Color.White)
+            }
+            Button(
+                onClick = {
+                    isRunning = false
+                    time = 0f
+                    GlobalScope.launch {
+                        currentDisplacement.snapTo(displacement)
+                    }
+
+                },
+                colors = ButtonDefaults.buttonColors(contentColor = Color.Gray)
+            ) {
+                Text("Reset", color = Color.White)
+            }
+        }
+
+        Text("Period: ${"%.2f".format(period)} s", color = Color.Yellow, modifier = Modifier.padding(8.dp),
+            fontSize = 20.sp,
+            fontWeight = FontWeight.SemiBold)
+
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(500.dp),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val springX = size.width / 2
+                val springY = equilibriumY + currentDisplacement.value
+
+                val coilCount = 10
+                val springHeight = springY - equilibriumY
+                val segmentHeight = springHeight / coilCount
+                val amplitude = 20f
+
+                for (i in 0 until coilCount) {
+                    val startX = springX + if (i % 2 == 0) -amplitude else amplitude
+                    val endX = springX + if (i % 2 == 0) amplitude else -amplitude
+                    val startY = equilibriumY + i * segmentHeight
+                    val endY = equilibriumY + (i + 1) * segmentHeight
+
+                    drawLine(
+                        color = Color.Black,
+                        start = Offset(startX, startY),
+                        end = Offset(endX, endY),
+                        strokeWidth = 4f,
+                        pathEffect = PathEffect.cornerPathEffect(4f)
+                    )
+                }
+                drawRect(
+                    color = Color.White,
+                    topLeft = Offset(springX - 40, springY),
+                    size = androidx.compose.ui.geometry.Size(80f, 40f)
+                )
+                val kineticEnergy = 0.5f * mass * (angularFrequency * currentDisplacement.value / 100).pow(2)
+                val potentialEnergy = 0.5f * springConstant * (currentDisplacement.value / 100).pow(2)
+                val totalEnergy = kineticEnergy + potentialEnergy
+
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
# Fixes #18  Add Pendulum and Spring Visualizations

## Overview
This pull request introduces the Pendulum and Spring simulation visualizations in the app. The Pendulum simulation allows users to interactively adjust the length and initial angle of a pendulum and observe the swinging motion in real time. The Spring simulation will similarly visualize oscillatory motion of a spring

### Features Added:
- **Pendulum Visualization:**
  - The user can adjust the pendulum's length and initial angle through interactive sliders.
  - Real-time physics simulation based on the parameters, showing the pendulum's motion.
  - Period calculation is displayed based on the length of the pendulum.
  - Start, Stop, and Reset buttons to control the simulation.
  

### Video
- **Pendulum Simulation Screen:**
 

https://github.com/user-attachments/assets/878c492a-c207-4184-8a3b-163626158c4d



- **Spring Simulation Screen:**
  

https://github.com/user-attachments/assets/8acb705e-50b8-4eb4-b997-904291fd9ad7
